### PR TITLE
Fix symbolization of order/payment attributes

### DIFF
--- a/lib/magento/cart.rb
+++ b/lib/magento/cart.rb
@@ -190,7 +190,7 @@ module Magento
       #
       # @return String: return the order id
       def order(attributes)
-        attributes.transform_keys(&:to_sym)
+        attributes = attributes.transform_keys(&:to_sym)
         url = "#{api_resource}/#{attributes[:cartId]}/order"
         request.put(url, attributes).parse
       end

--- a/lib/magento/guest_cart.rb
+++ b/lib/magento/guest_cart.rb
@@ -89,7 +89,7 @@ module Magento
       #
       # @return String: return the order id
       def payment_information(attributes)
-        attributes.transform_keys(&:to_sym)
+        attributes = attributes.transform_keys(&:to_sym)
         url = "#{api_resource}/#{attributes[:cartId]}/payment-information"
         request.post(url, attributes).parse
       end

--- a/spec/magento/cart_spec.rb
+++ b/spec/magento/cart_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe Magento::Cart do
+  let(:magento_client) { Magento::Request.new }
+
+  before do
+    allow(Magento::Cart).to receive(:request).and_return(magento_client)
+  end
+
+  describe '.order' do
+    it 'accepts string keyed attributes' do
+      attributes = {
+        'cartId' => '123',
+        'paymentMethod' => { method: 'cashondelivery' },
+        'email' => 'customer@example.com'
+      }
+      response = double('Response', parse: 'order_id', status: 200)
+
+      expect(magento_client).to receive(:put)
+        .with('carts/123/order', {
+          cartId: '123',
+          paymentMethod: { method: 'cashondelivery' },
+          email: 'customer@example.com'
+        })
+        .and_return(response)
+
+      expect(Magento::Cart.order(attributes)).to eql('order_id')
+    end
+  end
+end
+
+RSpec.describe Magento::GuestCart do
+  let(:magento_client) { Magento::Request.new }
+
+  before do
+    allow(Magento::GuestCart).to receive(:request).and_return(magento_client)
+  end
+
+  describe '.payment_information' do
+    it 'accepts string keyed attributes' do
+      attributes = {
+        'cartId' => 'abc123',
+        'paymentMethod' => { method: 'checkmo' },
+        'email' => 'guest@example.com'
+      }
+      response = double('Response', parse: 'order_id', status: 200)
+
+      expect(magento_client).to receive(:post)
+        .with('guest-carts/abc123/payment-information', {
+          cartId: 'abc123',
+          paymentMethod: { method: 'checkmo' },
+          email: 'guest@example.com'
+        })
+        .and_return(response)
+
+      expect(Magento::GuestCart.payment_information(attributes)).to eql('order_id')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- ensure Cart.order converts keys to symbols before accessing
- ensure GuestCart.payment_information converts keys to symbols
- test handling of string keyed attributes for Cart.order and GuestCart.payment_information

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_685aacc2733883268628bfe970c8ca2e