### PR TITLE
Fix tier price quantity typo

### DIFF
--- a/lib/magento/product.rb
+++ b/lib/magento/product.rb
@@ -77,7 +77,7 @@ module Magento
 
     # Add {price} on product {sku} for specified {customer_group_id}
     # 
-    # Param {quantity} is the minimun amount to apply the price
+    # Param {quantity} is the minimum amount to apply the price
     # 
     # product = Magento::Product.find(1)
     # product.add_tier_price(3.99, quantity: 1, customer_group_id: :all)
@@ -178,7 +178,7 @@ module Magento
 
       # Add {price} on product {sku} for specified {customer_group_id}
       # 
-      # Param {quantity} is the minimun amount to apply the price
+      # Param {quantity} is the minimum amount to apply the price
       # 
       # @return {Boolean}
       def add_tier_price(sku, price, quantity:, customer_group_id: :all)


### PR DESCRIPTION
## Summary
- fix a typo in tier price comments

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_685aacb088b48326b23ad32a1fc7e986