### PR TITLE
Fix madia_id typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,11 +568,11 @@ Example:
 ```rb
 product = Magento::Product.find('sku')
 
-product.add_media(madia_id)
+product.add_media(media_id)
 
 # or through the class method
 
-Magento::Product.add_media('sku', madia_id)
+Magento::Product.add_media('sku', media_id)
 ```
 
 ### Add tier price to product


### PR DESCRIPTION
## Summary
- correct `madia_id` typo in the README example

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_685aac6a4f5883269b8e1f59c198b411